### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/QrCode.Generator/security/code-scanning/1](https://github.com/BoBoBaSs84/QrCode.Generator/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since this workflow only checks out code and runs .NET build/test commands (and does not appear to require write access to the repository or to issues/pull-requests), the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to set it at the workflow level unless a job requires different permissions. The change should be made near the top of the file, after the `name` key and before the `on` key.