### PR TITLE
feat: Add support for multiple QR code export formats

### DIFF
--- a/src/QR-Code.API/Contracts/Base/CodeRequestBase.cs
+++ b/src/QR-Code.API/Contracts/Base/CodeRequestBase.cs
@@ -7,6 +7,8 @@
 // -----------------------------------------------------------------------------
 using System.ComponentModel.DataAnnotations;
 
+using QRCode.API.Enumerators;
+
 using static QRCoder.QRCodeGenerator;
 
 namespace QRCode.API.Contracts.Base;
@@ -16,6 +18,11 @@ namespace QRCode.API.Contracts.Base;
 /// </summary>
 public abstract class CodeRequestBase
 {
+  /// <summary>
+  /// Gets or sets the export type to use.
+  /// </summary>
+  public ExportType ExportType { get; init; }
+
   /// <summary>
   /// Gets or sets the error correction level to use.
   /// </summary>

--- a/src/QR-Code.API/Enumerators/ExportType.cs
+++ b/src/QR-Code.API/Enumerators/ExportType.cs
@@ -1,0 +1,42 @@
+﻿// -----------------------------------------------------------------------------
+// Copyright:	Robert Peter Meyer
+// License:		MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------------
+using System.ComponentModel;
+
+namespace QRCode.API.Enumerators;
+
+/// <summary>
+/// The export type enumerator.
+/// </summary>
+public enum ExportType
+{
+  /// <summary>
+  /// Windows Bitmap Graphics
+  /// </summary>
+  [Description("Windows Bitmap Graphics")]
+  BMP = 0,
+  /// <summary>
+  /// Portable Network Graphics
+  /// </summary>
+  [Description("Portable Network Graphics")]
+  PNG = 1,
+  /// <summary>
+  /// Joint Photographic Experts Group
+  /// </summary>
+  [Description("Joint Photographic Experts Group")]
+  JPEG = 2,
+  /// <summary>
+  /// Scalable Vector Graphics
+  /// </summary>
+  [Description("Scalable Vector Graphics")]
+  SVG = 3,
+  /// <summary>
+  /// Portable Document Format
+  /// </summary>
+  [Description("Portable Document Format")]
+  PDF = 4
+}

--- a/src/QR-Code.API/Extensions/SwaggerOptionsExtensions.cs
+++ b/src/QR-Code.API/Extensions/SwaggerOptionsExtensions.cs
@@ -1,4 +1,11 @@
-﻿using Swashbuckle.AspNetCore.Swagger;
+﻿// -----------------------------------------------------------------------------
+// Copyright:	Robert Peter Meyer
+// License:		MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------------
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace QRCode.API.Extensions;
 

--- a/src/QR-Code.API/Extensions/SwaggerUIOptionsExtensions.cs
+++ b/src/QR-Code.API/Extensions/SwaggerUIOptionsExtensions.cs
@@ -1,4 +1,11 @@
-﻿using Swashbuckle.AspNetCore.SwaggerUI;
+﻿// -----------------------------------------------------------------------------
+// Copyright:	Robert Peter Meyer
+// License:		MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+// -----------------------------------------------------------------------------
+using Swashbuckle.AspNetCore.SwaggerUI;
 
 namespace QRCode.API.Extensions;
 


### PR DESCRIPTION
feat: Add support for multiple QR code export formats

Introduced the `ExportType` property in `CodeRequestBase` to allow specifying the desired QR code export format. Added the `ExportType` enumerator to define supported formats (BMP, PNG, JPEG, SVG, PDF) with descriptions.

Refactored the `GenerateBarCode` method in `QRCodeService` to dynamically handle export formats using a new `GetExportBytesAndMimeType` method. Added helper methods for generating QR codes in each format, leveraging the `QRCoder` library.

Defined MIME types for each export format and updated namespaces and imports. Improved code modularity and extensibility by separating format-specific logic into distinct methods.