### PR TITLE
fix: refactor `ViewModel` command logic and model properties

### DIFF
--- a/src/QrCode.Generator/Controls/ContactDataControl.xaml
+++ b/src/QrCode.Generator/Controls/ContactDataControl.xaml
@@ -119,7 +119,6 @@
                     Content="Create"
                     Command="{Binding CreateCommand}"
                     CommandParameter="{Binding Model}"
-                    IsEnabled="{Binding Model.IsValid, UpdateSourceTrigger=PropertyChanged}"
                     Margin="1" />
             <Button x:Name="CopyButton"
                     Grid.Column="1"
@@ -127,7 +126,6 @@
                     Content="Copy"
                     Command="{Binding CopyCommand}"
                     CommandParameter="{Binding Model}"
-                    IsEnabled="{Binding Model.IsValid, UpdateSourceTrigger=PropertyChanged}"
                     Margin="1" />
             <Button x:Name="SaveButton"
                     Grid.Column="2"

--- a/src/QrCode.Generator/Controls/EventCodeControl.xaml
+++ b/src/QrCode.Generator/Controls/EventCodeControl.xaml
@@ -111,7 +111,6 @@
                     Content="Create"
                     Command="{Binding CreateCommand}"
                     CommandParameter="{Binding Model}"
-                    IsEnabled="{Binding Model.IsValid, UpdateSourceTrigger=PropertyChanged}"
                     Margin="1" />
             <Button x:Name="CopyButton"
                     Grid.Column="1"
@@ -119,7 +118,6 @@
                     Content="Copy"
                     Command="{Binding CopyCommand}"
                     CommandParameter="{Binding Model}"
-                    IsEnabled="{Binding Model.IsValid, UpdateSourceTrigger=PropertyChanged}"
                     Margin="1" />
             <Button x:Name="SaveButton"
                     Grid.Column="2"

--- a/src/QrCode.Generator/Controls/GiroCodeControl.xaml
+++ b/src/QrCode.Generator/Controls/GiroCodeControl.xaml
@@ -123,7 +123,6 @@
                     Content="Create"
                     Command="{Binding CreateCommand}"
                     CommandParameter="{Binding Model}"
-                    IsEnabled="{Binding Model.IsValid, UpdateSourceTrigger=PropertyChanged}"
                     Margin="1" />
             <Button x:Name="CopyButton"
                     Grid.Column="1"
@@ -131,7 +130,6 @@
                     Content="Copy"
                     Command="{Binding CopyCommand}"
                     CommandParameter="{Binding Model}"
-                    IsEnabled="{Binding Model.IsValid, UpdateSourceTrigger=PropertyChanged}"
                     Margin="1" />
             <Button x:Name="SaveButton"
                     Grid.Column="2"

--- a/src/QrCode.Generator/Controls/WifiCodeControl.xaml
+++ b/src/QrCode.Generator/Controls/WifiCodeControl.xaml
@@ -95,7 +95,6 @@
                     Content="Create"
                     Command="{Binding CreateCommand}"
                     CommandParameter="{Binding Model}"
-                    IsEnabled="{Binding Model.IsValid, UpdateSourceTrigger=PropertyChanged}"
                     Margin="1" />
             <Button x:Name="CopyButton"
                     Grid.Column="1"
@@ -103,7 +102,6 @@
                     Content="Copy"
                     Command="{Binding CopyCommand}"
                     CommandParameter="{Binding Model}"
-                    IsEnabled="{Binding Model.IsValid, UpdateSourceTrigger=PropertyChanged}"
                     Margin="1" />
             <Button x:Name="SaveButton"
                     Grid.Column="2"

--- a/src/QrCode.Generator/Models/ContactDataModel.cs
+++ b/src/QrCode.Generator/Models/ContactDataModel.cs
@@ -7,8 +7,6 @@
 // -----------------------------------------------------------------------------
 using System.ComponentModel.DataAnnotations;
 
-using BB84.Notifications.Attributes;
-
 using QrCode.Generator.Models.Base;
 
 using static QRCoder.PayloadGenerator.ContactData;
@@ -23,23 +21,7 @@ public sealed class ContactDataModel : QrCodeModel
   private ContactOutputType _outputType;
   private string _firstName;
   private string _lastName;
-  private string? _nickName;
-  private string? _phone;
-  private string? _mobilePhone;
-  private string? _officePhone;
-  private string? _email;
-  private DateTime? _dateOfBirth;
-  private string? _webSite;
-  private string? _street;
-  private string? _houseNumber;
-  private string? _city;
-  private string? _country;
-  private string? _zipCode;
-  private string? _note;
-  private string? _stateRegion;
   private AddressOrder _addressOrder;
-  private string? _org;
-  private string? _orgTitle;
 
   /// <summary>
   /// Initializes an instance of <see cref="ContactDataModel"/> class.
@@ -65,7 +47,6 @@ public sealed class ContactDataModel : QrCodeModel
   /// The first name.
   /// </summary>
   [Required]
-  [NotifyChanged(nameof(IsValid))]
   public string FirstName
   {
     get => _firstName;
@@ -76,7 +57,6 @@ public sealed class ContactDataModel : QrCodeModel
   /// The last name.
   /// </summary>
   [Required]
-  [NotifyChanged(nameof(IsValid))]
   public string LastName
   {
     get => _lastName;
@@ -88,52 +68,48 @@ public sealed class ContactDataModel : QrCodeModel
   /// </summary>
   public string? NickName
   {
-    get => _nickName;
-    set => SetProperty(ref _nickName, value);
+    get;
+    set => SetProperty(ref field, value);
   }
 
   /// <summary>
   /// The normal phone number.
   /// </summary>
   [Phone]
-  [NotifyChanged(nameof(IsValid))]
   public string? Phone
   {
-    get => _phone;
-    set => SetPropertyAndValidate(ref _phone, value);
+    get;
+    set => SetPropertyAndValidate(ref field, value);
   }
 
   /// <summary>
   /// The mobile phone number.
   /// </summary>
   [Phone]
-  [NotifyChanged(nameof(IsValid))]
   public string? MobilePhone
   {
-    get => _mobilePhone;
-    set => SetPropertyAndValidate(ref _mobilePhone, value);
+    get;
+    set => SetPropertyAndValidate(ref field, value);
   }
 
   /// <summary>
   /// The office phone number.
   /// </summary>
   [Phone]
-  [NotifyChanged(nameof(IsValid))]
   public string? OfficePhone
   {
-    get => _officePhone;
-    set => SetPropertyAndValidate(ref _officePhone, value);
+    get;
+    set => SetPropertyAndValidate(ref field, value);
   }
 
   /// <summary>
   /// The E-Mail address.
   /// </summary>
   [EmailAddress]
-  [NotifyChanged(nameof(IsValid))]
   public string? Email
   {
-    get => _email;
-    set => SetPropertyAndValidate(ref _email, value);
+    get;
+    set => SetPropertyAndValidate(ref field, value);
   }
 
   /// <summary>
@@ -141,19 +117,18 @@ public sealed class ContactDataModel : QrCodeModel
   /// </summary>
   public DateTime? Birthday
   {
-    get => _dateOfBirth;
-    set => SetProperty(ref _dateOfBirth, value);
+    get;
+    set => SetProperty(ref field, value);
   }
 
   /// <summary>
   ///	Website / Homepage
   /// </summary>
   [Url]
-  [NotifyChanged(nameof(IsValid))]
   public string? WebSite
   {
-    get => _webSite;
-    set => SetProperty(ref _webSite, value);
+    get;
+    set => SetPropertyAndValidate(ref field, value);
   }
 
   /// <summary>
@@ -161,8 +136,8 @@ public sealed class ContactDataModel : QrCodeModel
   /// </summary>
   public string? Street
   {
-    get => _street;
-    set => SetProperty(ref _street, value);
+    get;
+    set => SetProperty(ref field, value);
   }
 
   /// <summary>
@@ -170,8 +145,8 @@ public sealed class ContactDataModel : QrCodeModel
   /// </summary>
   public string? HouseNumber
   {
-    get => _houseNumber;
-    set => SetProperty(ref _houseNumber, value);
+    get;
+    set => SetProperty(ref field, value);
   }
 
   /// <summary>
@@ -179,8 +154,8 @@ public sealed class ContactDataModel : QrCodeModel
   /// </summary>
   public string? City
   {
-    get => _city;
-    set => SetProperty(ref _city, value);
+    get;
+    set => SetProperty(ref field, value);
   }
 
   /// <summary>
@@ -188,8 +163,8 @@ public sealed class ContactDataModel : QrCodeModel
   /// </summary>
   public string? Country
   {
-    get => _country;
-    set => SetProperty(ref _country, value);
+    get;
+    set => SetProperty(ref field, value);
   }
 
   /// <summary>
@@ -197,8 +172,8 @@ public sealed class ContactDataModel : QrCodeModel
   /// </summary>
   public string? ZipCode
   {
-    get => _zipCode;
-    set => SetProperty(ref _zipCode, value);
+    get;
+    set => SetProperty(ref field, value);
   }
 
   /// <summary>
@@ -206,8 +181,8 @@ public sealed class ContactDataModel : QrCodeModel
   /// </summary>
   public string? Note
   {
-    get => _note;
-    set => SetProperty(ref _note, value);
+    get;
+    set => SetProperty(ref field, value);
   }
 
   /// <summary>
@@ -215,8 +190,8 @@ public sealed class ContactDataModel : QrCodeModel
   /// </summary>
   public string? StateRegion
   {
-    get => _stateRegion;
-    set => SetProperty(ref _stateRegion, value);
+    get;
+    set => SetProperty(ref field, value);
   }
 
   /// <summary>
@@ -236,8 +211,8 @@ public sealed class ContactDataModel : QrCodeModel
   /// </summary>
   public string? Org
   {
-    get => _org;
-    set => SetProperty(ref _org, value);
+    get;
+    set => SetProperty(ref field, value);
   }
 
   /// <summary>
@@ -245,8 +220,8 @@ public sealed class ContactDataModel : QrCodeModel
   /// </summary>
   public string? OrgTitle
   {
-    get => _orgTitle;
-    set => SetProperty(ref _orgTitle, value);
+    get;
+    set => SetProperty(ref field, value);
   }
 
   /// <inheritdoc/>

--- a/src/QrCode.Generator/Models/EventCodeModel.cs
+++ b/src/QrCode.Generator/Models/EventCodeModel.cs
@@ -48,7 +48,6 @@ public sealed class EventCodeModel : QrCodeModel
   /// The subject / title of the calender event.
   /// </summary>
   [Required(AllowEmptyStrings = false), StringLength(100, MinimumLength = 1)]
-  [NotifyChanged(nameof(IsValid))]
   public string Subject
   {
     get => _subject;
@@ -77,7 +76,7 @@ public sealed class EventCodeModel : QrCodeModel
   /// The start time of the event.
   /// </summary>
   [Required]
-  [NotifyChanged(nameof(IsValid), nameof(End))]
+  [NotifyChanged(nameof(End))]
   public DateTime Start
   {
     get => _start;
@@ -88,7 +87,7 @@ public sealed class EventCodeModel : QrCodeModel
   /// The end time of the event.
   /// </summary>
   [Required]
-  [NotifyChanged(nameof(IsValid), nameof(Start))]
+  [NotifyChanged(nameof(Start))]
   public DateTime End
   {
     get => _end;
@@ -116,7 +115,7 @@ public sealed class EventCodeModel : QrCodeModel
   public EventEncoding Encoding
   {
     get => _encoding;
-    set => SetProperty(ref _encoding, value);
+    set => SetPropertyAndValidate(ref _encoding, value);
   }
 
   /// <inheritdoc/>

--- a/src/QrCode.Generator/Models/GiroCodeModel.cs
+++ b/src/QrCode.Generator/Models/GiroCodeModel.cs
@@ -7,8 +7,6 @@
 // -----------------------------------------------------------------------------
 using System.ComponentModel.DataAnnotations;
 
-using BB84.Notifications.Attributes;
-
 using QrCode.Generator.Models.Base;
 
 using static QRCoder.PayloadGenerator.Girocode;
@@ -25,10 +23,8 @@ public sealed class GiroCodeModel : QrCodeModel
   private string _name;
   private decimal _amount;
   private string _reference;
-  private TypeOfRemittance _type;
   private string _purpose;
   private string _message;
-  private GirocodeVersion _version;
   private GirocodeEncoding _encoding;
 
   /// <summary>
@@ -50,7 +46,6 @@ public sealed class GiroCodeModel : QrCodeModel
   /// Account number of the Beneficiary. Only IBAN is allowed.
   /// </summary>
   [Required, RegularExpression(@"^[a-zA-Z]{2}[0-9]{2}([a-zA-Z0-9]?){16,30}$")]
-  [NotifyChanged(nameof(IsValid))]
   public string IBAN
   {
     get => _iban;
@@ -61,7 +56,6 @@ public sealed class GiroCodeModel : QrCodeModel
   /// BIC of the Beneficiary Bank.
   /// </summary>
   [Required, RegularExpression(@"^[A-Z0-9]{4}[A-Z]{2}[A-Z0-9]{2}(?:[A-Z0-9]{3})?$")]
-  [NotifyChanged(nameof(IsValid))]
   public string BIC
   {
     get => _bic;
@@ -72,7 +66,6 @@ public sealed class GiroCodeModel : QrCodeModel
   /// Name of the Beneficiary.
   /// </summary>
   [Required]
-  [NotifyChanged(nameof(IsValid))]
   public string Name
   {
     get => _name;
@@ -86,7 +79,6 @@ public sealed class GiroCodeModel : QrCodeModel
   /// Amount must be more than 0.01 and less than 999999999.99
   /// </remarks>
   [Range(0.01, 999999999.99)]
-  [NotifyChanged(nameof(IsValid))]
   public decimal Amount
   {
     get => _amount;
@@ -97,7 +89,6 @@ public sealed class GiroCodeModel : QrCodeModel
   /// Remittance Information (Purpose-/reference text).
   /// </summary>  
   [StringLength(140)]
-  [NotifyChanged(nameof(IsValid))]
   public string Reference
   {
     get => _reference;
@@ -111,11 +102,10 @@ public sealed class GiroCodeModel : QrCodeModel
   /// (e.g. ISO 11649 RF Creditor Reference)
   /// </remarks>
   [Required]
-  [NotifyChanged(nameof(IsValid))]
   public TypeOfRemittance Type
   {
-    get => _type;
-    set => SetPropertyAndValidate(ref _type, value);
+    get;
+    set => SetPropertyAndValidate(ref field, value);
   }
 
   /// <summary>
@@ -140,18 +130,16 @@ public sealed class GiroCodeModel : QrCodeModel
   /// Girocode version.
   /// </summary>
   [Required]
-  [NotifyChanged(nameof(IsValid))]
   public GirocodeVersion Version
   {
-    get => _version;
-    set => SetPropertyAndValidate(ref _version, value);
+    get;
+    set => SetPropertyAndValidate(ref field, value);
   }
 
   /// <summary>
   /// Encoding of the Girocode payload.
   /// </summary>
   [Required]
-  [NotifyChanged(nameof(IsValid))]
   public GirocodeEncoding Encoding
   {
     get => _encoding;

--- a/src/QrCode.Generator/Models/WifiCodeModel.cs
+++ b/src/QrCode.Generator/Models/WifiCodeModel.cs
@@ -7,8 +7,6 @@
 // -----------------------------------------------------------------------------
 using System.ComponentModel.DataAnnotations;
 
-using BB84.Notifications.Attributes;
-
 using QrCode.Generator.Models.Base;
 
 using static QRCoder.PayloadGenerator.WiFi;
@@ -21,7 +19,7 @@ namespace QrCode.Generator.Models;
 public sealed class WifiCodeModel : QrCodeModel
 {
   private Authentication _authentication;
-  private string _sSID;
+  private string _ssid;
   private string _password;
   private bool _hidden;
 
@@ -31,7 +29,7 @@ public sealed class WifiCodeModel : QrCodeModel
   public WifiCodeModel()
   {
     _authentication = Authentication.WPA;
-    _sSID = string.Empty;
+    _ssid = string.Empty;
     _password = string.Empty;
     _hidden = false;
   }
@@ -40,22 +38,20 @@ public sealed class WifiCodeModel : QrCodeModel
   /// The authentication mode to use.
   /// </summary>
   [Required]
-  [NotifyChanged(nameof(IsValid))]
   public Authentication Authentication
   {
     get => _authentication;
-    set => SetProperty(ref _authentication, value);
+    set => SetPropertyAndValidate(ref _authentication, value);
   }
 
   /// <summary>
   /// The service set identifier.
   /// </summary>
   [Required]
-  [NotifyChanged(nameof(IsValid))]
   public string SSID
   {
-    get => _sSID;
-    set => SetPropertyAndValidate(ref _sSID, value);
+    get => _ssid;
+    set => SetPropertyAndValidate(ref _ssid, value);
   }
 
   /// <summary>

--- a/src/QrCode.Generator/ViewModels/Base/QrCodeViewModel.cs
+++ b/src/QrCode.Generator/ViewModels/Base/QrCodeViewModel.cs
@@ -5,6 +5,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 // -----------------------------------------------------------------------------
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -28,23 +29,45 @@ namespace QrCode.Generator.ViewModels.Base;
 /// <summary>
 /// The qr code view model base class.
 /// </summary>
-/// <remarks>
-/// Initializes an instance of <see cref="QrCodeViewModel{T}"/> class.
-/// </remarks>
-/// <param name="qrCodeService">The QR code service instance to use.</param>
-/// <param name="exportService">The export service instance to use.</param>
-/// <param name="templateService">The template service instance to use.</param>
-/// <param name="model">The model instance to use.</param>
-public abstract class QrCodeViewModel<T>(IQrCodeService qrCodeService, IExportService<T> exportService, ITemplateService<T> templateService, T model)
-  : ViewModelBase, ITemplatable<T>, IExportable<T> where T : QrCodeModel
+public abstract class QrCodeViewModel<T> : ViewModelBase, ITemplatable<T>, IExportable<T> where T : QrCodeModel
 {
+  private readonly IQrCodeService _qrCodeService;
+  private readonly IExportService<T> _exportService;
+  private readonly ITemplateService<T> _templateService;
+  private readonly ActionCommand<QrCodeModel> _createCommand;
+  private readonly ActionCommand<QrCodeModel> _copyCommand;
+
   private Image _qrCodeImage = new();
   private string _payload = string.Empty;
 
   /// <summary>
+  /// Initializes an instance of <see cref="QrCodeViewModel{T}"/> class.
+  /// </summary>
+  /// <param name="qrCodeService">The QR code service instance to use.</param>
+  /// <param name="exportService">The export service instance to use.</param>
+  /// <param name="templateService">The template service instance to use.</param>
+  /// <param name="model">The model instance to use.</param>
+  protected QrCodeViewModel(IQrCodeService qrCodeService, IExportService<T> exportService, ITemplateService<T> templateService, T model)
+  {
+    _qrCodeService = qrCodeService;
+    _exportService = exportService;
+    _templateService = templateService;
+    _createCommand = new(UpdateQrCode, CanExecute);
+    _copyCommand = new(CopyQrCode, CanExecute);
+
+    Model = model;
+    Model.PropertyChanged += OnModelPropertyChanged;
+    Model.ErrorsChanged += OnModelErrorsChanged;
+
+    // The model reports no errors until it has been validated at least once,
+    // so an empty model would otherwise start out as valid.
+    Model.Validate();
+  }
+
+  /// <summary>
   /// The model instance to use.
   /// </summary>
-  public T Model { get; } = model;
+  public T Model { get; }
 
   /// <summary>
   /// The actual qr code payload to encode.
@@ -90,13 +113,28 @@ public abstract class QrCodeViewModel<T>(IQrCodeService qrCodeService, IExportSe
   /// The command to create or update the QR code.
   /// </summary>
   public IActionCommand<QrCodeModel> CreateCommand
-    => new ActionCommand<QrCodeModel>(UpdateQrCode);
+    => _createCommand;
 
   /// <summary>
   /// The command for copying the QR code.
   /// </summary>
   public IActionCommand<QrCodeModel> CopyCommand
-    => new ActionCommand<QrCodeModel>(CopyQrCode);
+    => _copyCommand;
+
+  private static bool CanExecute(QrCodeModel model)
+    => model is not null && model.IsValid;
+
+  private void OnModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    => RaiseCanExecuteChanged();
+
+  private void OnModelErrorsChanged(object? sender, DataErrorsChangedEventArgs e)
+    => RaiseCanExecuteChanged();
+
+  private void RaiseCanExecuteChanged()
+  {
+    _createCommand.RaiseCanExecuteChanged();
+    _copyCommand.RaiseCanExecuteChanged();
+  }
 
   /// <inheritdoc/>
   public IActionCommand<T> LoadTemplateCommand
@@ -114,7 +152,7 @@ public abstract class QrCodeViewModel<T>(IQrCodeService qrCodeService, IExportSe
   /// Exports the qr code.
   /// </summary>
   protected virtual void Export()
-    => exportService.Export(ExportPath, ExportType, Payload, Model);
+    => _exportService.Export(ExportPath, ExportType, Payload, Model);
 
   /// <summary>
   /// Loads the template into the current model.
@@ -122,8 +160,8 @@ public abstract class QrCodeViewModel<T>(IQrCodeService qrCodeService, IExportSe
   /// <param name="model">The model to load into.</param>
   protected virtual void LoadTemplate(T model)
   {
-    string fileContent = templateService.Load(LoadPath);
-    T template = templateService.From(fileContent);
+    string fileContent = _templateService.Load(LoadPath);
+    T template = _templateService.From(fileContent);
     model.FromTemplate(template);
   }
 
@@ -133,8 +171,8 @@ public abstract class QrCodeViewModel<T>(IQrCodeService qrCodeService, IExportSe
   /// <param name="model">The model to save from.</param>
   protected virtual void SaveTemplate(T model)
   {
-    string jsonContent = templateService.To(model);
-    templateService.Save(SavePath, jsonContent);
+    string jsonContent = _templateService.To(model);
+    _templateService.Save(SavePath, jsonContent);
   }
 
   /// <summary>
@@ -149,7 +187,7 @@ public abstract class QrCodeViewModel<T>(IQrCodeService qrCodeService, IExportSe
   {
     SetPayLoad();
 
-    DrawingImage drawing = qrCodeService
+    DrawingImage drawing = _qrCodeService
       .CreateDrawing(Payload, 20, model.ForegroundColor, model.BackgroundColor, model.ErrorCorrection);
 
     QrCodeImage.Source = drawing;
@@ -162,7 +200,7 @@ public abstract class QrCodeViewModel<T>(IQrCodeService qrCodeService, IExportSe
   {
     SetPayLoad();
 
-    BitmapSource bitmap = qrCodeService
+    BitmapSource bitmap = _qrCodeService
       .CreateBitmap(Payload, 20, model.ForegroundColor, model.BackgroundColor, model.ErrorCorrection);
 
     DataObject dataObject = new();

--- a/tests/QrCode.GeneratorTests/ViewModels/ContactDataViewModelTests.cs
+++ b/tests/QrCode.GeneratorTests/ViewModels/ContactDataViewModelTests.cs
@@ -35,7 +35,16 @@ public sealed class ContactDataViewModelTests : UnitTestBase
     Mock<IQrCodeService> qrCodeServiceMock = new();
     Mock<IExportService<ContactDataModel>> exportServiceMock = new();
     Mock<ITemplateService<ContactDataModel>> templateServiceMock = new();
-    ContactDataViewModel viewModel = new(qrCodeServiceMock.Object, exportServiceMock.Object, templateServiceMock.Object, new());
+    ContactDataModel model = new()
+    {
+      FirstName = "UnitTest",
+      LastName = "UnitTest",
+      Phone = "+1 505-644-9930",
+      MobilePhone = "+1 203-337-9287",
+      OfficePhone = "+1 505-288-3106",
+      Email = "UnitTest@UnitTest.org"
+    };
+    ContactDataViewModel viewModel = new(qrCodeServiceMock.Object, exportServiceMock.Object, templateServiceMock.Object, model);
 
     viewModel.CreateCommand.Execute(viewModel.Model);
 

--- a/tests/QrCode.GeneratorTests/ViewModels/EventCodeViewModelTests.cs
+++ b/tests/QrCode.GeneratorTests/ViewModels/EventCodeViewModelTests.cs
@@ -34,7 +34,15 @@ public sealed class EventViewModelTests : UnitTestBase
     Mock<IQrCodeService> qrCodeServiceMock = new();
     Mock<IExportService<EventCodeModel>> exportServiceMock = new();
     Mock<ITemplateService<EventCodeModel>> templateServiceMock = new();
-    EventCodeViewModel viewModel = new(qrCodeServiceMock.Object, exportServiceMock.Object, templateServiceMock.Object, new());
+    EventCodeModel model = new()
+    {
+      Subject = "UnitTest",
+      Description = "UnitTest",
+      Location = "UnitTest",
+      Start = DateTime.Today,
+      End = DateTime.Today
+    };
+    EventCodeViewModel viewModel = new(qrCodeServiceMock.Object, exportServiceMock.Object, templateServiceMock.Object, model);
 
     viewModel.CreateCommand.Execute(viewModel.Model);
 

--- a/tests/QrCode.GeneratorTests/ViewModels/WifiCodeViewModelTests.cs
+++ b/tests/QrCode.GeneratorTests/ViewModels/WifiCodeViewModelTests.cs
@@ -11,6 +11,8 @@ using QrCode.Generator.Interfaces.Services;
 using QrCode.Generator.Models;
 using QrCode.Generator.ViewModels;
 
+using static QRCoder.PayloadGenerator.WiFi;
+
 namespace QrCode.GeneratorTests.ViewModels;
 
 [TestClass]
@@ -34,10 +36,35 @@ public sealed class WifiCodeViewModelTests : UnitTestBase
     Mock<IQrCodeService> qrCodeServiceMock = new();
     Mock<IExportService<WifiCodeModel>> exportServiceMock = new();
     Mock<ITemplateService<WifiCodeModel>> templateServiceMock = new();
-    WifiCodeViewModel viewModel = new(qrCodeServiceMock.Object, exportServiceMock.Object, templateServiceMock.Object, new());
+    WifiCodeModel model = new()
+    {
+      SSID = "UnitTest",
+      Password = "UnitTest",
+      Authentication = Authentication.WPA
+    };
+    WifiCodeViewModel viewModel = new(qrCodeServiceMock.Object, exportServiceMock.Object, templateServiceMock.Object, model);
 
     viewModel.CreateCommand.Execute(viewModel.Model);
 
     Assert.AreNotEqual(string.Empty, viewModel.Payload);
+  }
+
+  [WpfTestMethod]
+  public void CreateCommandCanExecuteTest()
+  {
+    Mock<IQrCodeService> qrCodeServiceMock = new();
+    Mock<IExportService<WifiCodeModel>> exportServiceMock = new();
+    Mock<ITemplateService<WifiCodeModel>> templateServiceMock = new();
+    WifiCodeViewModel viewModel = new(qrCodeServiceMock.Object, exportServiceMock.Object, templateServiceMock.Object, new());
+    int canExecuteChangedCount = 0;
+    viewModel.CreateCommand.CanExecuteChanged += (sender, args) => canExecuteChangedCount++;
+
+    Assert.AreSame(viewModel.CreateCommand, viewModel.CreateCommand);
+    Assert.IsFalse(viewModel.CreateCommand.CanExecute(viewModel.Model));
+
+    viewModel.Model.SSID = "UnitTest";
+
+    Assert.IsTrue(viewModel.CreateCommand.CanExecute(viewModel.Model));
+    Assert.IsGreaterThan(0, canExecuteChangedCount);
   }
 }


### PR DESCRIPTION
**Changes:**

- Removed `IsEnabled` bindings from XAML, shifting enablement to `ViewModel` command logic.
- Refactored `ContactDataModel`, `GiroCodeModel`, and `WifiCodeModel` to use auto-properties and `SetProperty` methods, removing `BB84.Notifications` attributes and unused fields.
- Rewrote `QrCodeViewModel<T>` for explicit command fields, `CanExecute` logic, and event handling.
- Updated `ViewModel` unit tests and added `CreateCommandCanExecuteTest` for `WifiCodeViewModel`.